### PR TITLE
Declare bencode in deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,1 @@
-{}
+{:deps {nrepl/bencode {:mvn/version "1.1.0"}}


### PR DESCRIPTION
It's used, but not declared. I think in bb it doesn't make a difference because it's included there, but when importing in just clojure the dep is missing.